### PR TITLE
Updated to work with Python 3

### DIFF
--- a/pyavrophonetic/utils/__init__.py
+++ b/pyavrophonetic/utils/__init__.py
@@ -22,11 +22,17 @@ You should have received a copy of the GNU General Public License
 along with pyAvroPhonetic.  If not, see <http://www.gnu.org/licenses/>.
 
 """
+import sys
 
 def utf(text):
     """Shortcut funnction for encoding given text with utf-8"""
+    version = sys.version_info[0]
     try:
-        output = unicode(text, encoding='utf-8')
+        # In Python 3 use str() instead of unicode()
+        if version == 2:
+            output = unicode(text, encoding='utf-8')
+        elif version == 3:
+            output = str(text, encoding='utf-8')
     except UnicodeDecodeError:
         output = text
     except TypeError:


### PR DESCRIPTION
unicode() function is deprecated in Python 3, so added a check for version of Python. If Python 3 is used then str() function will be called to convert the text instead of unicode(). Ran the tests and did some ad hoc parsing with both Python 2 and 3.
