### PR TITLE
Fix: In python 3 strings are unicode by default..

### DIFF
--- a/pyavrophonetic/utils/__init__.py
+++ b/pyavrophonetic/utils/__init__.py
@@ -24,6 +24,13 @@ along with pyAvroPhonetic.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 def utf(text):
+    """In python 3 strings are unicode by default."""
+    try:
+        unicode        # check if unicode is defined
+    except NameError:  # not found: python 3: replace by str
+        unicode = str
+
+
     """Shortcut funnction for encoding given text with utf-8"""
     try:
         output = unicode(text, encoding='utf-8')


### PR DESCRIPTION
In python 3 strings are unicode by default. So, I add the a try except block to catch to make the code compatible with python3.

https://docs.python.org/3.0/whatsnew/3.0.html#text-vs-data-instead-of-unicode-vs-8-bit